### PR TITLE
Allow access from on-prem to port 2003

### DIFF
--- a/groups/application/sg.tf
+++ b/groups/application/sg.tf
@@ -30,7 +30,7 @@ resource "aws_security_group_rule" "clients" {
 
   security_group_id = module.gfn_app_ec2_security_group.this_security_group_id
   description       = "Allow on-premise client traffic"
-  for_each          = toset(["3000","8083","8086"])
+  for_each          = toset(["3000","8083","8086","2003"])
   type              = "ingress"
   from_port         = each.value
   to_port           = each.value


### PR DESCRIPTION
There are some FESS scripts running on-prem that use the graphite listen port to send data to influxdb, so this adds ingress for 2003 to on-prem ips.