### PR TITLE
Allow AssumeRole of security hub read only role

### DIFF
--- a/groups/application/data.tf
+++ b/groups/application/data.tf
@@ -34,3 +34,7 @@ data "vault_generic_secret" "kms_keys" {
 data "vault_generic_secret" "security_kms_keys" {
   path = "aws-accounts/security/kms"
 }
+
+data "vault_generic_secret" "account_ids" {
+  path = "aws-accounts/account-ids"
+}

--- a/groups/application/iam.tf
+++ b/groups/application/iam.tf
@@ -30,6 +30,16 @@ module "gfn_app_profile" {
       actions = [
         "route53:ChangeResourceRecordSets"
       ]
+    },
+    {
+      sid       = "AllowAsumeRoleForSecurityHubReadOnlyAccess"
+      effect    = "Allow"
+      resources = [
+        "arn:aws:iam::${local.account_ids["security"]}:role/security-hub-analytics-role"
+      ]
+      actions   = [
+        "sts:AssumeRole"
+      ]
     }
   ]
 }

--- a/groups/application/locals.tf
+++ b/groups/application/locals.tf
@@ -9,7 +9,7 @@ locals {
   grafana_cw_logs    = { for log, map in var.grafana_cw_logs : log => merge(map, { "log_group_name" = "${var.application}-fe-${log}" }) }
   grafana_log_groups = compact([for log, map in local.grafana_cw_logs : lookup(map, "log_group_name", "")])
 
-
+  account_ids            = data.vault_generic_secret.account_ids.data
   kms_keys_data          = data.vault_generic_secret.kms_keys.data
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
   logs_kms_key_id        = local.kms_keys_data["logs"]


### PR DESCRIPTION
Updates the analyticdata EC2 instance permissions to allow access to the security hub read only role in the security account, in order to extract metrics and chart them.

 